### PR TITLE
feat: fetch header instead of whole block

### DIFF
--- a/operator/registration.go
+++ b/operator/registration.go
@@ -106,13 +106,13 @@ func (o *Operator) RegisterOperatorWithAvs(
 		o.logger.Errorf("Unable to get current block number")
 		return err
 	}
-	curBlock, err := o.ethClient.BlockByNumber(context.Background(), big.NewInt(int64(curBlockNum)))
+	curBlock, err := o.ethClient.HeaderByNumber(context.Background(), big.NewInt(int64(curBlockNum)))
 	if err != nil {
 		o.logger.Errorf("Unable to get current block")
 		return err
 	}
 	sigValidForSeconds := int64(1_000_000)
-	operatorToAvsRegistrationSigExpiry := big.NewInt(int64(curBlock.Time()) + sigValidForSeconds)
+	operatorToAvsRegistrationSigExpiry := big.NewInt(int64(curBlock.Time) + sigValidForSeconds)
 	_, err = o.avsWriter.RegisterOperatorInQuorumWithAVSRegistryCoordinator(
 		context.Background(),
 		operatorEcdsaKeyPair, operatorToAvsRegistrationSigSalt, operatorToAvsRegistrationSigExpiry,


### PR DESCRIPTION
Depends on #80

Fetching the whole block includes parsing all transactions needlessly, which limits compatibility with non-L1 networks. Since all we need is the timestamp, we can fetch the header only instead.